### PR TITLE
Fix WP Cron not running

### DIFF
--- a/communityhive.php
+++ b/communityhive.php
@@ -4,7 +4,7 @@
  * Author: Community Hive
  * Author URI: https://www.communityhive.com
  * Description: Community Hive allows your members to follow their favorite communities to receive updates.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Requires PHP: 8.1
  */
 
@@ -31,14 +31,15 @@ if (file_exists(__DIR__ . '/src/.env')) {
 Config::define('ACORN_BASEPATH', rtrim(plugin_dir_path(__FILE__).'src', '/'));
 Config::define('WP_ENV', env('APP_ENV', 'production'));
 Config::define('COMMUNITY_HIVE_BASE_URL', env('COMMUNITY_HIVE_BASE_URL', 'https://www.communityhive.com/api/v1/'));
-Config::define('COMMUNITY_HIVE_PLUGIN_VERSION', '1.0.0');
+Config::define('COMMUNITY_HIVE_PLUGIN_VERSION', '1.0.1');
 Config::define('COMMUNITY_HIVE_PLUGIN_FILE', __FILE__);
 Config::define('COMMUNITY_HIVE_PLUGIN_URL', plugin_dir_url(__FILE__));
 Config::apply();
 
 /**
- * Experimental features
+ * Acorn configuration
  */
+putenv('APP_RUNNING_IN_CONSOLE=false');
 putenv('ACORN_ENABLE_EXPIRIMENTAL_ROUTER=true');
 
 /**


### PR DESCRIPTION
Set APP_RUNNING_IN_CONSOLE env var to false to stop loading acorns CLI when attempting to run the WP-Cron via PHP CLI