### PR TITLE
Fixed name spacing issue with Symfony dependency

### DIFF
--- a/communityhive.php
+++ b/communityhive.php
@@ -4,7 +4,7 @@
  * Author: Community Hive
  * Author URI: https://www.communityhive.com
  * Description: Community Hive allows your members to follow their favorite communities to receive updates.
- * Version: 1.0.1
+ * Version: 1.0.2
  * Requires PHP: 8.1
  */
 
@@ -31,7 +31,7 @@ if (file_exists(__DIR__ . '/src/.env')) {
 Config::define('ACORN_BASEPATH', rtrim(plugin_dir_path(__FILE__).'src', '/'));
 Config::define('WP_ENV', env('APP_ENV', 'production'));
 Config::define('COMMUNITY_HIVE_BASE_URL', env('COMMUNITY_HIVE_BASE_URL', 'https://www.communityhive.com/api/v1/'));
-Config::define('COMMUNITY_HIVE_PLUGIN_VERSION', '1.0.1');
+Config::define('COMMUNITY_HIVE_PLUGIN_VERSION', '1.0.2');
 Config::define('COMMUNITY_HIVE_PLUGIN_FILE', __FILE__);
 Config::define('COMMUNITY_HIVE_PLUGIN_URL', plugin_dir_url(__FILE__));
 Config::apply();

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -14,8 +14,9 @@ return [
         Finder::create()
             ->files()
             ->ignoreVCS(true)
-            ->notName('/LICENSE|.*\\.md|.*\\.dist|Makefile|composer\\.json|composer\\.lock/')
+	        ->notName('/LICENSE|.*\\.md|.*\\.dist|Makefile|composer\\.json|composer\\.lock|Dockerfile|docker-compose.yml/')
             ->exclude([
+				'bin',
                 'doc',
                 'test',
                 'test_old',
@@ -26,25 +27,27 @@ return [
             ->in('vendor'),
         Finder::create()->append([
             'communityhive.php',
-            'composer.json'
-        ])
+            'composer.json',
+        ]),
     ],
     'exclude-files' => [
         ...array_values(array_map(
-	        static fn (SplFileInfo $fileInfo) => $fileInfo->getPathName(),
-	        iterator_to_array(
-		        Finder::create()
-		              ->files()
-		              ->in('vendor/illuminate/console/resources/views/components')
-	        ),
-        ))
+            static fn (SplFileInfo $fileInfo) => $fileInfo->getPathName(),
+            iterator_to_array(
+                Finder::create()
+                    ->files()
+                    ->in('vendor/illuminate/console/resources/views/components')
+                    ->in('vendor/symfony/error-handler/Resources/views')
+            ),
+        )),
     ],
     'patchers' => [],
     'exclude-namespaces' => [
         'CommunityHive\App',
         'CommunityHive\Database',
         'CommunityHive\Tests',
-        'Illuminate'
+        'Illuminate',
+        'Symfony',
     ],
     'exclude-classes' => ['WP', 'WP_Theme', 'WP_CLI', 'WP_User'],
     'exclude-functions' => ['get_theme_file_path', 'apply_filters'],


### PR DESCRIPTION
Remove Symfony from namespacing and add an exclusion filter for symfony's error handler view files