### PR TITLE
Fix activation test error

### DIFF
--- a/communityhive.php
+++ b/communityhive.php
@@ -4,7 +4,7 @@
  * Author: Community Hive
  * Author URI: https://www.communityhive.com
  * Description: Community Hive allows your members to follow their favorite communities to receive updates.
- * Version: 1.0.2
+ * Version: 1.0.3
  * Requires PHP: 8.1
  */
 
@@ -31,7 +31,7 @@ if (file_exists(__DIR__ . '/src/.env')) {
 Config::define('ACORN_BASEPATH', rtrim(plugin_dir_path(__FILE__).'src', '/'));
 Config::define('WP_ENV', env('APP_ENV', 'production'));
 Config::define('COMMUNITY_HIVE_BASE_URL', env('COMMUNITY_HIVE_BASE_URL', 'https://www.communityhive.com/api/v1/'));
-Config::define('COMMUNITY_HIVE_PLUGIN_VERSION', '1.0.2');
+Config::define('COMMUNITY_HIVE_PLUGIN_VERSION', '1.0.3');
 Config::define('COMMUNITY_HIVE_PLUGIN_FILE', __FILE__);
 Config::define('COMMUNITY_HIVE_PLUGIN_URL', plugin_dir_url(__FILE__));
 Config::apply();

--- a/src/app/Http/Middleware/AuthenticateJwt.php
+++ b/src/app/Http/Middleware/AuthenticateJwt.php
@@ -4,6 +4,8 @@ namespace CommunityHive\App\Http\Middleware;
 
 use Closure;
 use CommunityHive\App\Contracts\CommunityHiveApiServiceContract;
+use CommunityHive\App\Http\Responses\ErrorResponse;
+use CommunityHive\App\Http\Responses\OkayResponse;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -17,16 +19,20 @@ class AuthenticateJwt
      */
     public function handle(Request $request, Closure $next): mixed
     {
+        if ($request->input('request_type') === 'test') {
+            return app()->make(OkayResponse::class);
+        }
+
         if (! $token = $request->getContent()) {
-            return response()->json([
-                'error' => 'There was no JWT included in the request.',
+            return app()->make(ErrorResponse::class, [
+                'message' => 'There was no JWT included in the request.',
             ]);
         }
 
         $apiService = app()->make(CommunityHiveApiServiceContract::class);
         if (! $payload = $apiService->decodeJwt($token)) {
-            return response()->json([
-                'error' => 'Unable to decode the provided JWT.',
+            return app()->make(ErrorResponse::class, [
+                'message' => 'Unable to decode the provided JWT.',
             ]);
         }
 


### PR DESCRIPTION
Fixes an error where the client was assuming a JWT would be present in the activation POST test. Now checks for the request_type form data and returns an okay response that us used during the CH activation process.